### PR TITLE
Refactoring

### DIFF
--- a/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/ModelFlattener.java
+++ b/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/ModelFlattener.java
@@ -1,5 +1,65 @@
 package org.emoflon.neo.emsl.refinement;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.EList;
+import org.emoflon.neo.emsl.eMSL.Entity;
+import org.emoflon.neo.emsl.eMSL.Model;
+import org.emoflon.neo.emsl.eMSL.ModelNodeBlock;
+import org.emoflon.neo.emsl.eMSL.RefinementCommand;
+import org.emoflon.neo.emsl.util.FlattenerErrorType;
+import org.emoflon.neo.emsl.util.FlattenerException;
+
 public class ModelFlattener extends PatternFlattener {
 
+	@Override
+	protected Map<String, List<ModelNodeBlock>> collectNodes(Entity entity, List<RefinementCommand> refinementList,
+			Set<String> alreadyRefinedEntityNames, boolean isSrc) throws FlattenerException {
+		var nodeBlocks = new HashMap<String, List<ModelNodeBlock>>();
+
+		for (var r : refinementList) {
+
+			if (!(r.getReferencedType() instanceof Model)) {
+				throw new FlattenerException(entity, FlattenerErrorType.NON_COMPLIANT_SUPER_ENTITY,
+						r.getReferencedType());
+			}
+
+			// add current entity to list of names to detect infinite loop
+			var alreadyRefinedEntityNamesCopy = new HashSet<String>(alreadyRefinedEntityNames);
+			alreadyRefinedEntityNamesCopy.add(dispatcher.getName(entity));
+
+			// recursively flatten superEntities
+			var nodeBlocksOfSuperEntity = new ArrayList<ModelNodeBlock>();
+
+			Entity flattenedSuperEntity = (flatten((Entity) r.getReferencedType(), alreadyRefinedEntityNamesCopy));
+
+			if (flattenedSuperEntity != null) {
+				EList<ModelNodeBlock> nodeBlocksOfFlattenedSuperEntity = dispatcher.getNodeBlocks(flattenedSuperEntity);
+
+				for (var nb : nodeBlocksOfFlattenedSuperEntity) {
+
+					// create new NodeBlock
+					var newNb = copyModelNodeBlock(nb, r);
+
+					// add nodeBlock to list according to its name
+					if (!nodeBlocks.containsKey(newNb.getName())) {
+						var<ModelNodeBlock> newList = new ArrayList<ModelNodeBlock>();
+						newList.add(newNb);
+						nodeBlocks.put(newNb.getName(), newList);
+					} else {
+						nodeBlocks.get(newNb.getName()).add(newNb);
+					}
+					nodeBlocksOfSuperEntity.add(newNb);
+				}
+
+				reAdjustTargetsOfEdges(nodeBlocksOfSuperEntity, r);
+			}
+		}
+		return nodeBlocks;
+	}
 }

--- a/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/PatternFlattener.java
+++ b/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/PatternFlattener.java
@@ -1,11 +1,21 @@
 package org.emoflon.neo.emsl.refinement;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.emf.common.util.EList;
+import org.emoflon.neo.emsl.eMSL.AtomicPattern;
+import org.emoflon.neo.emsl.eMSL.EMSLFactory;
 import org.emoflon.neo.emsl.eMSL.Entity;
+import org.emoflon.neo.emsl.eMSL.MetamodelRelationStatement;
 import org.emoflon.neo.emsl.eMSL.ModelNodeBlock;
+import org.emoflon.neo.emsl.eMSL.ModelRelationStatement;
+import org.emoflon.neo.emsl.eMSL.ModelRelationStatementType;
+import org.emoflon.neo.emsl.eMSL.Pattern;
 import org.emoflon.neo.emsl.eMSL.RefinementCommand;
 import org.emoflon.neo.emsl.util.FlattenerErrorType;
 import org.emoflon.neo.emsl.util.FlattenerException;
@@ -54,5 +64,271 @@ public class PatternFlattener extends AbstractEntityFlattener {
 		}
 
 		return entity;
+	}
+	
+	@Override
+	protected Map<String, List<ModelNodeBlock>> collectNodes(Entity entity, List<RefinementCommand> refinementList,
+			Set<String> alreadyRefinedEntityNames, boolean isSrc) throws FlattenerException {
+		var nodeBlocks = new HashMap<String, List<ModelNodeBlock>>();
+
+		for (var r : refinementList) {
+
+			if (!(r.getReferencedType() instanceof AtomicPattern)) {
+				throw new FlattenerException(entity, FlattenerErrorType.NON_COMPLIANT_SUPER_ENTITY,
+						r.getReferencedType());
+			}
+
+			// add current entity to list of names to detect infinite loop
+			var alreadyRefinedEntityNamesCopy = new HashSet<String>(alreadyRefinedEntityNames);
+			alreadyRefinedEntityNamesCopy.add(dispatcher.getName(entity));
+
+			// recursively flatten superEntities
+			var nodeBlocksOfSuperEntity = new ArrayList<ModelNodeBlock>();
+
+			var flattenedSuperEntity = (flatten((Entity) r.getReferencedType().eContainer(),
+						alreadyRefinedEntityNamesCopy));
+
+			// check if a superEntity possesses a condition block
+			if (r.getReferencedType() instanceof AtomicPattern
+					&& ((Pattern) r.getReferencedType().eContainer()).getCondition() != null) {
+				throw new FlattenerException(entity, FlattenerErrorType.REFINE_ENTITY_WITH_CONDITION,
+						r.getReferencedType());
+			}
+
+			if (flattenedSuperEntity != null) {
+				EList<ModelNodeBlock> nodeBlocksOfFlattenedSuperEntity = dispatcher.
+						getNodeBlocks(flattenedSuperEntity);
+
+				for (var nb : nodeBlocksOfFlattenedSuperEntity) {
+
+					// create new NodeBlock
+					var newNb = copyModelNodeBlock(nb, r);
+
+					// add nodeBlock to list according to its name
+					if (!nodeBlocks.containsKey(newNb.getName())) {
+						var newList = new ArrayList<ModelNodeBlock>();
+						newList.add(newNb);
+						nodeBlocks.put(newNb.getName(), newList);
+					} else {
+						nodeBlocks.get(newNb.getName()).add(newNb);
+					}
+					nodeBlocksOfSuperEntity.add(newNb);
+				}
+
+				reAdjustTargetsOfEdges(nodeBlocksOfSuperEntity, r);
+			}
+		}
+		return nodeBlocks;
+	}
+	
+	@Override
+	protected List<ModelNodeBlock> mergeEdgesOfNodeBlocks(Entity entity, Map<String, List<ModelNodeBlock>> nodeBlocks,
+			List<ModelNodeBlock> mergedNodes) throws FlattenerException {
+
+		// collect all edges in hashmap; first key is type name, second is target name
+		for (var name : nodeBlocks.keySet()) {
+			var namedEdges = new HashMap<String, ArrayList<ModelRelationStatement>>();
+			var edges = new HashMap<String, HashMap<String, ArrayList<ModelRelationStatement>>>();
+			for (var nb : nodeBlocks.get(name)) {
+
+				// ----------- simple edges ----------- //
+				for (var rel : nb.getRelations()) {
+					if (rel.getTypes() == null) {
+						continue;
+					}
+					// collect edges that have no names -> simple edges (only one type) => merging
+					// does not change
+					if (rel.getName() == null) {
+						if (rel.getTarget() != null) {
+							if (!edges.containsKey(rel.getTypes().get(0).getType().getName())) {
+								edges.put(rel.getTypes().get(0).getType().getName(),
+										new HashMap<String, ArrayList<ModelRelationStatement>>());
+							}
+							if (!edges.get(rel.getTypes().get(0).getType().getName())
+									.containsKey(rel.getTarget().getName())) {
+								edges.get(rel.getTypes().get(0).getType().getName()).put(rel.getTarget().getName(),
+										new ArrayList<ModelRelationStatement>());
+							}
+							edges.get(rel.getTypes().get(0).getType().getName()).get(rel.getTarget().getName())
+									.add(rel);
+						} else if (rel.getProxyTarget() != null) {
+							if (!edges.containsKey(rel.getTypes().get(0).getType().getName())) {
+								edges.put(rel.getTypes().get(0).getType().getName(),
+										new HashMap<String, ArrayList<ModelRelationStatement>>());
+							}
+							if (!edges.get(rel.getTypes().get(0).getType().getName())
+									.containsKey(rel.getProxyTarget())) {
+								edges.get(rel.getTypes().get(0).getType().getName()).put(rel.getProxyTarget(),
+										new ArrayList<ModelRelationStatement>());
+							}
+							edges.get(rel.getTypes().get(0).getType().getName()).get(rel.getProxyTarget()).add(rel);
+						}
+					} else if (rel.getName() != null) {
+						if (!namedEdges.containsKey(rel.getName())) {
+							namedEdges.put(rel.getName(), new ArrayList<ModelRelationStatement>());
+						}
+						namedEdges.get(rel.getName()).add(rel);
+					}
+				}
+			}
+
+			// iterate over all types and targets to create new RelationStatement that is
+			// the result of the merging
+			for (var typename : edges.keySet()) {
+				for (var targetname : edges.get(typename).keySet()) {
+					var newRel = EMSLFactory.eINSTANCE.createModelRelationStatement();
+
+					// merge statements and check statements for compliance
+					newRel.getProperties().addAll(
+							collectAndMergePropertyStatementsOfRelations(edges.get(typename).get(targetname), entity));
+
+					// check and merge action
+					newRel.setAction(mergeActionOfRelations(edges.get(typename).get(targetname)));
+
+					// create new ModelRelationStatementType for the new ModelRelationStatement
+					var newRelType = EMSLFactory.eINSTANCE.createModelRelationStatementType();
+					newRelType.setType((edges.get(typename).get(targetname).get(0).getTypes().get(0).getType()));
+					// collect all types of the edges that are to be merged (should be one type each
+					// in this case) to merge the bounds
+					var typesOfEdges = new ArrayList<ModelRelationStatementType>();
+					for (var e : edges.get(typename).get(targetname)) {
+						typesOfEdges.addAll(e.getTypes());
+					}
+					var bounds = mergeModelRelationStatementPathLimits(entity, typesOfEdges);
+					if (bounds != null) {
+						newRelType.setLower(bounds[0].toString());
+						newRelType.setUpper(bounds[1].toString());
+					}
+					newRel.getTypes().add(newRelType);
+					mergedNodes.forEach(nb -> {
+						if (nb.getName().equals(targetname)) {
+							newRel.setTarget(nb);
+						}
+						if (nb.getName().equals(name)) {
+							nb.getRelations().add(newRel);
+						}
+					});
+				}
+			}
+
+			// ------------ edges with multiple types ------------- //
+
+			for (var n : namedEdges.keySet()) {
+				var newRel = EMSLFactory.eINSTANCE.createModelRelationStatement();
+				newRel.setName(n);
+
+				var intersection = new ArrayList<MetamodelRelationStatement>();
+				namedEdges.get(n).get(0).getTypes().forEach(t -> intersection.add(t.getType()));
+				for (var e : namedEdges.get(n)) {
+					var typesOfOther = new ArrayList<MetamodelRelationStatement>();
+					e.getTypes().forEach(t -> typesOfOther.add(t.getType()));
+					intersection.retainAll(typesOfOther);
+				}
+
+				if (intersection.isEmpty())
+					throw new FlattenerException(entity,
+							FlattenerErrorType.NO_INTERSECTION_IN_MODEL_RELATION_STATEMENT_TYPE_LIST);
+
+				for (var t : intersection) {
+					// create new ModelRelationStatementType for each remaining type
+					var newRelType = EMSLFactory.eINSTANCE.createModelRelationStatementType();
+					newRelType.setType(t);
+					newRel.getTypes().add(newRelType);
+
+					var typesOfEdges = new ArrayList<ModelRelationStatementType>();
+					for (var e : namedEdges.get(n)) {
+						for (var tmp : e.getTypes()) {
+							if (t == tmp.getType()) {
+								typesOfEdges.add(tmp);
+							}
+						}
+					}
+					var bounds = mergeModelRelationStatementPathLimits(entity, typesOfEdges);
+					if (bounds != null) {
+						newRelType.setLower(bounds[0].toString());
+						newRelType.setUpper(bounds[1].toString());
+					}
+				}
+
+				// merge statements and check statements for compliance
+				newRel.getProperties().addAll(collectAndMergePropertyStatementsOfRelations(namedEdges.get(n), entity));
+
+				// check and merge action
+				newRel.setAction(mergeActionOfRelations(namedEdges.get(n)));
+
+				mergedNodes.forEach(nb -> {
+					if (nb.getName().equals(namedEdges.get(n).get(0).getTarget().getName())) {
+						newRel.setTarget(nb);
+					}
+					if (nb.getName().equals(name)) {
+						nb.getRelations().add(newRel);
+					}
+				});
+			}
+		}
+
+		return removeDuplicateEdges(mergedNodes);
+	}
+	
+	/**
+	 * This method merges the lower and upper lengths of simple paths in
+	 * ModelRelationStatementTypes. The result is the maximum of the lower and the
+	 * minimum of the upper limits.
+	 * 
+	 * @param entity that is to be flattened.
+	 * @param types  whose lower and upper limits must be merged.
+	 * @return Array of two values representing the new lower and upper path
+	 *         lengths.
+	 * @throws FlattenerException is thrown if the lower limit of the path length is
+	 *                            greater than the upper limit (does not make
+	 *                            sense).
+	 */
+	protected Object[] mergeModelRelationStatementPathLimits(Entity entity, ArrayList<ModelRelationStatementType> types)
+			throws FlattenerException {
+		var bounds = new Object[2];
+		bounds[0] = 1;
+		bounds[1] = "*";
+
+		boolean empty = true;
+		for (var t : types) {
+			if (t.getLower() != null && t.getUpper() != null) {
+				empty = false;
+			}
+		}
+		if (empty)
+			return null;
+
+		for (var t : types) {
+			if (t.getLower() != null && t.getUpper() != null) {
+				try {
+					if (Integer.parseInt(t.getLower()) > Integer.parseInt(bounds[0].toString())) {
+						bounds[0] = Integer.parseInt(t.getLower());
+					}
+				} catch (NumberFormatException e) {
+					if (t.getLower().equals("*") && !bounds[0].equals("*")) {
+						bounds[0] = "*";
+					}
+				}
+				try {
+					if (Integer.parseInt(t.getUpper()) < Integer.parseInt(bounds[1].toString())) {
+						bounds[1] = Integer.parseInt(t.getUpper());
+					}
+				} catch (NumberFormatException e) {
+					if (!t.getUpper().equals("*") && bounds[1].equals("*")) {
+						bounds[1] = Integer.parseInt(t.getUpper());
+					}
+				}
+			}
+			if (bounds[0] instanceof Integer) {
+				if (bounds[1] instanceof Integer && (int) bounds[0] > (int) bounds[1]) {
+					// lower bound is greater than upper => does not make sense => exception
+					throw new FlattenerException(entity, FlattenerErrorType.PATH_LENGTHS_NONSENSE, t);
+				}
+			} else if (bounds[0].equals("*") && !bounds[1].equals("*")) {
+				throw new FlattenerException(entity, FlattenerErrorType.PATH_LENGTHS_NONSENSE, t);
+			}
+		}
+
+		return bounds;
 	}
 }

--- a/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/RuleFlattener.java
+++ b/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/RuleFlattener.java
@@ -1,5 +1,144 @@
 package org.emoflon.neo.emsl.refinement;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.EList;
+import org.emoflon.neo.emsl.eMSL.EMSLFactory;
+import org.emoflon.neo.emsl.eMSL.Entity;
+import org.emoflon.neo.emsl.eMSL.MetamodelNodeBlock;
+import org.emoflon.neo.emsl.eMSL.ModelNodeBlock;
+import org.emoflon.neo.emsl.eMSL.RefinementCommand;
+import org.emoflon.neo.emsl.eMSL.Rule;
+import org.emoflon.neo.emsl.util.FlattenerErrorType;
+import org.emoflon.neo.emsl.util.FlattenerException;
+
 public class RuleFlattener extends PatternFlattener {
 
+	@Override
+	protected Map<String, List<ModelNodeBlock>> collectNodes(Entity entity, List<RefinementCommand> refinementList,
+			Set<String> alreadyRefinedEntityNames, boolean isSrc) throws FlattenerException {
+		var nodeBlocks = new HashMap<String, List<ModelNodeBlock>>();
+
+		for (var r : refinementList) {
+
+			if (!(r.getReferencedType() instanceof Rule)) {
+				throw new FlattenerException(entity, FlattenerErrorType.NON_COMPLIANT_SUPER_ENTITY,
+						r.getReferencedType());
+			}
+
+			// add current entity to list of names to detect infinite loop
+			var alreadyRefinedEntityNamesCopy = new HashSet<String>(alreadyRefinedEntityNames);
+			alreadyRefinedEntityNamesCopy.add(dispatcher.getName(entity));
+
+			// recursively flatten superEntities
+			var nodeBlocksOfSuperEntity = new ArrayList<ModelNodeBlock>();
+
+			Entity flattenedSuperEntity = (flatten((Entity) r.getReferencedType(), alreadyRefinedEntityNamesCopy));
+
+			// check if a superEntity possesses a condition block
+			if (r.getReferencedType() instanceof Rule
+					&& ((Rule) r.getReferencedType()).getCondition() != null) {
+				throw new FlattenerException(entity, FlattenerErrorType.REFINE_ENTITY_WITH_CONDITION,
+						r.getReferencedType());
+			}
+
+			if (flattenedSuperEntity != null) {
+				EList<ModelNodeBlock> nodeBlocksOfFlattenedSuperEntity = dispatcher.getNodeBlocks(flattenedSuperEntity);
+
+				for (var nb : nodeBlocksOfFlattenedSuperEntity) {
+
+					// create new NodeBlock
+					var newNb = copyModelNodeBlock(nb, r);
+
+					// add nodeBlock to list according to its name
+					if (!nodeBlocks.containsKey(newNb.getName())) {
+						var<ModelNodeBlock> newList = new ArrayList<ModelNodeBlock>();
+						newList.add(newNb);
+						nodeBlocks.put(newNb.getName(), newList);
+					} else {
+						nodeBlocks.get(newNb.getName()).add(newNb);
+					}
+					nodeBlocksOfSuperEntity.add(newNb);
+				}
+
+				reAdjustTargetsOfEdges(nodeBlocksOfSuperEntity, r);
+			}
+		}
+		return nodeBlocks;
+	}
+	
+	@Override
+	protected List<ModelNodeBlock> mergeNodes(Entity entity, List<RefinementCommand> refinementList,
+			Map<String, List<ModelNodeBlock>> nodeBlocks) throws FlattenerException {
+		var mergedNodes = new ArrayList<ModelNodeBlock>();
+
+		// take all nodeBlocks with the same name/key out of the HashMap and merge
+		for (var name : nodeBlocks.keySet()) {
+			var blocksWithKey = nodeBlocks.get(name);
+
+			Comparator<MetamodelNodeBlock> comparator = new Comparator<MetamodelNodeBlock>() {
+				@Override
+				public int compare(MetamodelNodeBlock o1, MetamodelNodeBlock o2) {
+					if (o1.getSuperTypes().contains(o2) || recursiveContainment(o1, o2, false)) {
+						return -1;
+					} else if (o2.getSuperTypes().contains(o1) || recursiveContainment(o2, o1, false)) {
+						return 1;
+					} else if (o1 == o2) {
+						return 0;
+					} else {
+						// no common type could be found, merge not possible
+						throw new AssertionError();
+					}
+				}
+
+				private boolean recursiveContainment(MetamodelNodeBlock o1, MetamodelNodeBlock o2,
+						boolean containment) {
+					var wrapper = new Object() {
+						boolean contains = false;
+					};
+
+					if (o1.getSuperTypes().contains(o2)) {
+						return true;
+					}
+
+					o1.getSuperTypes().forEach(st -> {
+						wrapper.contains = (recursiveContainment(st, o2, containment));
+					});
+					return wrapper.contains;
+				}
+			};
+
+			// store/sort types in this PriorityQueue
+			PriorityQueue<MetamodelNodeBlock> nodeBlockTypeQueue = new PriorityQueue<MetamodelNodeBlock>(comparator);
+
+			// collect types
+			for (var nb : blocksWithKey) {
+				if (nb.getType() != null) {
+					try {
+						nodeBlockTypeQueue.add(nb.getType());
+					} catch (AssertionError e) {
+						throw new FlattenerException(entity, FlattenerErrorType.NO_COMMON_SUBTYPE_OF_NODES, nb);
+					}
+				}
+			}
+
+			// create new NodeBlock that will be added to the entity
+			var newNb = EMSLFactory.eINSTANCE.createModelNodeBlock();
+			newNb.setType(nodeBlockTypeQueue.peek());
+			newNb.setName(name);
+			newNb.setAction(mergeActionOfNodes(blocksWithKey));
+
+			mergedNodes.add(newNb);
+		}
+
+		return mergeEdgesOfNodeBlocks(entity, nodeBlocks,
+				mergePropertyStatementsOfNodeBlocks(entity, nodeBlocks, mergedNodes));
+	}
 }

--- a/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/TripleRuleFlattener.java
+++ b/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/refinement/TripleRuleFlattener.java
@@ -1,13 +1,20 @@
 package org.emoflon.neo.emsl.refinement;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emoflon.neo.emsl.eMSL.Correspondence;
+import org.emoflon.neo.emsl.eMSL.EMSLFactory;
 import org.emoflon.neo.emsl.eMSL.Entity;
+import org.emoflon.neo.emsl.eMSL.MetamodelNodeBlock;
 import org.emoflon.neo.emsl.eMSL.ModelNodeBlock;
 import org.emoflon.neo.emsl.eMSL.RefinementCommand;
 import org.emoflon.neo.emsl.eMSL.TripleRule;
@@ -90,6 +97,133 @@ public class TripleRuleFlattener extends AbstractEntityFlattener {
 		}
 
 		return (T) entity;
+	}
+	
+	@Override
+	protected Map<String, List<ModelNodeBlock>> collectNodes(Entity entity, List<RefinementCommand> refinementList,
+			Set<String> alreadyRefinedEntityNames, boolean isSrc) throws FlattenerException {
+		var nodeBlocks = new HashMap<String, List<ModelNodeBlock>>();
+
+		for (var r : refinementList) {
+
+			if (!(r.getReferencedType() instanceof TripleRule)) {
+				throw new FlattenerException(entity, FlattenerErrorType.NON_COMPLIANT_SUPER_ENTITY,
+						r.getReferencedType());
+			}
+
+			// add current entity to list of names to detect infinite loop
+			var alreadyRefinedEntityNamesCopy = new HashSet<String>(alreadyRefinedEntityNames);
+			alreadyRefinedEntityNamesCopy.add(dispatcher.getName(entity));
+
+			// recursively flatten superEntities
+			var nodeBlocksOfSuperEntity = new ArrayList<ModelNodeBlock>();
+
+			Entity flattenedSuperEntity = (flatten((Entity) r.getReferencedType(), alreadyRefinedEntityNamesCopy));
+
+			// check if a superEntity possesses a condition block
+			if (r.getReferencedType() instanceof TripleRule
+					&& !((TripleRule) r.getReferencedType()).getNacs().isEmpty()) {
+				throw new FlattenerException(entity, FlattenerErrorType.REFINE_ENTITY_WITH_CONDITION,
+						r.getReferencedType());
+			}
+
+			if (flattenedSuperEntity != null) {
+				EList<ModelNodeBlock> nodeBlocksOfFlattenedSuperEntity = null;
+
+				if (isSrc)
+					nodeBlocksOfFlattenedSuperEntity = ((TripleRule) flattenedSuperEntity).getSrcNodeBlocks();
+				else {
+					nodeBlocksOfFlattenedSuperEntity = ((TripleRule) flattenedSuperEntity).getTrgNodeBlocks();
+				}
+
+				for (var nb : nodeBlocksOfFlattenedSuperEntity) {
+
+					// create new NodeBlock
+					var newNb = copyModelNodeBlock(nb, r);
+
+					// add nodeBlock to list according to its name
+					if (!nodeBlocks.containsKey(newNb.getName())) {
+						var<ModelNodeBlock> newList = new ArrayList<ModelNodeBlock>();
+						newList.add(newNb);
+						nodeBlocks.put(newNb.getName(), newList);
+					} else {
+						nodeBlocks.get(newNb.getName()).add(newNb);
+					}
+					nodeBlocksOfSuperEntity.add(newNb);
+				}
+
+				reAdjustTargetsOfEdges(nodeBlocksOfSuperEntity, r);
+			}
+		}
+		return nodeBlocks;
+	}
+	
+	@Override
+	protected List<ModelNodeBlock> mergeNodes(Entity entity, List<RefinementCommand> refinementList,
+			Map<String, List<ModelNodeBlock>> nodeBlocks) throws FlattenerException {
+		var mergedNodes = new ArrayList<ModelNodeBlock>();
+
+		// take all nodeBlocks with the same name/key out of the HashMap and merge
+		for (var name : nodeBlocks.keySet()) {
+			var blocksWithKey = nodeBlocks.get(name);
+
+			Comparator<MetamodelNodeBlock> comparator = new Comparator<MetamodelNodeBlock>() {
+				@Override
+				public int compare(MetamodelNodeBlock o1, MetamodelNodeBlock o2) {
+					if (o1.getSuperTypes().contains(o2) || recursiveContainment(o1, o2, false)) {
+						return -1;
+					} else if (o2.getSuperTypes().contains(o1) || recursiveContainment(o2, o1, false)) {
+						return 1;
+					} else if (o1 == o2) {
+						return 0;
+					} else {
+						// no common type could be found, merge not possible
+						throw new AssertionError();
+					}
+				}
+
+				private boolean recursiveContainment(MetamodelNodeBlock o1, MetamodelNodeBlock o2,
+						boolean containment) {
+					var wrapper = new Object() {
+						boolean contains = false;
+					};
+
+					if (o1.getSuperTypes().contains(o2)) {
+						return true;
+					}
+
+					o1.getSuperTypes().forEach(st -> {
+						wrapper.contains = (recursiveContainment(st, o2, containment));
+					});
+					return wrapper.contains;
+				}
+			};
+
+			// store/sort types in this PriorityQueue
+			PriorityQueue<MetamodelNodeBlock> nodeBlockTypeQueue = new PriorityQueue<MetamodelNodeBlock>(comparator);
+
+			// collect types
+			for (var nb : blocksWithKey) {
+				if (nb.getType() != null) {
+					try {
+						nodeBlockTypeQueue.add(nb.getType());
+					} catch (AssertionError e) {
+						throw new FlattenerException(entity, FlattenerErrorType.NO_COMMON_SUBTYPE_OF_NODES, nb);
+					}
+				}
+			}
+
+			// create new NodeBlock that will be added to the entity
+			var newNb = EMSLFactory.eINSTANCE.createModelNodeBlock();
+			newNb.setType(nodeBlockTypeQueue.peek());
+			newNb.setName(name);
+			newNb.setAction(mergeActionOfNodes(blocksWithKey));
+
+			mergedNodes.add(newNb);
+		}
+
+		return mergeEdgesOfNodeBlocks(entity, nodeBlocks,
+				mergePropertyStatementsOfNodeBlocks(entity, nodeBlocks, mergedNodes));
 	}
 
 	/**


### PR DESCRIPTION
Every flattener now possesses own collectNodes method, the one in AbstractEntityFlattener can be made abstract if the metamodelFlattener is removed (have not done this yet, only emptied it to keep the project compiling)

Tests were green