### PR TITLE
Fixes Correspondences in TGG not being correctly affected by relabeling during refinements. (Closes #294)

### DIFF
--- a/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/validation/EMSLValidator.xtend
+++ b/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/validation/EMSLValidator.xtend
@@ -868,10 +868,10 @@ class EMSLValidator extends AbstractEMSLValidator {
 	 */
 	@Check
 	def void typeOfSourceTargetInCorrespondence(Correspondence corr) {
-		if (corr.source?.type != corr.type.source) {
+		if (corr.source !== null && corr.source?.type != corr.type.source) {
 			error('''The source argument must be of type "«corr.type.source.name»".''', corr, EMSLPackage.Literals.CORRESPONDENCE__SOURCE)
 		}
-		if (corr.target?.type != corr.type.target) {
+		if (corr.target !== null && corr.target?.type != corr.type.target) {
 			error('''The target argument must be of type "«corr.type.target.name»".''', corr, EMSLPackage.Literals.CORRESPONDENCE__TARGET)
 		}
 	}


### PR DESCRIPTION
Regarding the missing correspondences when using relabeling: I added that the flattener checks for relabelings in the refinements and if there are relabelings concerning the correspondences, the nodes in source and target are replaced by proxies using the new labels, during merging the different correspondences they are used to determine the correct source and target `ModelNodeBlocks`. On the given example, the correspondences are now shown for all cases.

Regarding the wrong validation: I added `NullPointer` checks which solved the issue in the given example.

The tests were all green.