### PR TITLE
Added interface for reporting inconsistencies

### DIFF
--- a/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/terminationcondition/CompositeTerminationCondition.java
+++ b/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/terminationcondition/CompositeTerminationCondition.java
@@ -1,0 +1,33 @@
+package org.emoflon.neo.engine.modules.terminationcondition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.emoflon.neo.cypher.patterns.NeoMatch;
+import org.emoflon.neo.cypher.rules.NeoCoMatch;
+import org.emoflon.neo.engine.generator.MatchContainer;
+import org.emoflon.neo.engine.generator.modules.ITerminationCondition;
+
+public class CompositeTerminationCondition implements ITerminationCondition<NeoMatch, NeoCoMatch> {
+
+	private List<ITerminationCondition<NeoMatch, NeoCoMatch>> terminationConditions;
+	
+	public CompositeTerminationCondition() {
+		this.terminationConditions = new ArrayList<>();
+	}
+	
+	public boolean add(ITerminationCondition<NeoMatch, NeoCoMatch> e) {
+		return terminationConditions.add(e);
+	}
+
+	@Override
+	public boolean isReached(MatchContainer<NeoMatch, NeoCoMatch> matchContainer) {
+		if(terminationConditions.isEmpty())
+			return true;
+		for(ITerminationCondition<NeoMatch, NeoCoMatch> terminationCondition : terminationConditions) {
+			if(terminationCondition.isReached(matchContainer))
+				return true;
+		}
+		return false;
+	}
+}

--- a/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/BackwardTransformationOperationalStrategy.java
+++ b/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/BackwardTransformationOperationalStrategy.java
@@ -5,6 +5,7 @@ import org.emoflon.neo.cypher.models.NeoCoreBuilder;
 import org.emoflon.neo.cypher.rules.NeoRule;
 import org.emoflon.neo.engine.api.constraints.IConstraint;
 import org.emoflon.neo.engine.generator.modules.ICleanupModule;
+import org.emoflon.neo.engine.generator.modules.IInconsistencyReporter;
 import org.emoflon.neo.engine.modules.ilp.ILPBasedOperationalStrategy;
 import org.emoflon.neo.engine.modules.ilp.ILPFactory.SupportedILPSolver;
 
@@ -20,6 +21,19 @@ public class BackwardTransformationOperationalStrategy extends ILPBasedOperation
 			String targetModel//
 	) {
 		super(solver, genRules, opRules, negativeConstraints, builder, sourceModel, targetModel);
+	}
+	
+	public BackwardTransformationOperationalStrategy(//
+			SupportedILPSolver solver, //
+			NeoCoreBuilder builder, //
+			Collection<NeoRule> genRules, //
+			Collection<NeoRule> opRules, //
+			Collection<IConstraint> negativeConstraints, //
+			IInconsistencyReporter inconsistencyReporter, //
+			String sourceModel, //
+			String targetModel//
+	) {
+		super(solver, genRules, opRules, negativeConstraints, inconsistencyReporter, builder, sourceModel, targetModel);
 	}
 
 	@Override

--- a/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/CheckOnlyOperationalStrategy.java
+++ b/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/CheckOnlyOperationalStrategy.java
@@ -12,6 +12,7 @@ import org.emoflon.neo.engine.api.constraints.IConstraint;
 import org.emoflon.neo.engine.api.rules.IRule;
 import org.emoflon.neo.engine.generator.MatchContainer;
 import org.emoflon.neo.engine.generator.modules.ICleanupModule;
+import org.emoflon.neo.engine.generator.modules.IInconsistencyReporter;
 import org.emoflon.neo.engine.generator.modules.IMonitor;
 import org.emoflon.neo.engine.modules.ilp.ILPBasedOperationalStrategy;
 import org.emoflon.neo.engine.modules.ilp.ILPFactory.SupportedILPSolver;
@@ -24,11 +25,24 @@ public class CheckOnlyOperationalStrategy extends ILPBasedOperationalStrategy im
 			Collection<NeoRule> genRules, //
 			Collection<NeoRule> opRules, //
 			Collection<IConstraint> negativeConstraints, //
+			IInconsistencyReporter inconsistencyReporter,
 			NeoCoreBuilder builder, //
 			String sourceModel, //
 			String targetModel//
 	) {
-		super(solver, genRules, opRules, negativeConstraints, builder, sourceModel, targetModel);
+		super(solver, genRules, opRules, negativeConstraints, inconsistencyReporter, builder, sourceModel, targetModel);
+	}
+	
+	public CheckOnlyOperationalStrategy(//
+			SupportedILPSolver solver, //
+			Collection<NeoRule> genRules, //
+			Collection<NeoRule> opRules, //
+			Collection<IConstraint> negativeConstraints, //
+			NeoCoreBuilder builder, //
+			String sourceModel, //
+			String targetModel//
+	) {
+		super(solver, genRules, opRules, negativeConstraints, null, builder, sourceModel, targetModel);
 	}
 
 	@Override

--- a/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/CorrCreationOperationalStrategy.java
+++ b/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/CorrCreationOperationalStrategy.java
@@ -5,6 +5,7 @@ import org.emoflon.neo.cypher.models.NeoCoreBuilder;
 import org.emoflon.neo.cypher.rules.NeoRule;
 import org.emoflon.neo.engine.api.constraints.IConstraint;
 import org.emoflon.neo.engine.generator.modules.ICleanupModule;
+import org.emoflon.neo.engine.generator.modules.IInconsistencyReporter;
 import org.emoflon.neo.engine.modules.ilp.ILPBasedOperationalStrategy;
 import org.emoflon.neo.engine.modules.ilp.ILPFactory.SupportedILPSolver;
 
@@ -20,6 +21,19 @@ public class CorrCreationOperationalStrategy extends ILPBasedOperationalStrategy
 			String targetModel//
 	) {
 		super(solver, genRules, opRules, negativeConstraints, builder, sourceModel, targetModel);
+	}
+	
+	public CorrCreationOperationalStrategy(//
+			SupportedILPSolver solver, //
+			NeoCoreBuilder builder, //
+			Collection<NeoRule> genRules, //
+			Collection<NeoRule> opRules, //
+			Collection<IConstraint> negativeConstraints, //
+			IInconsistencyReporter inconsistencyReporter, //
+			String sourceModel, //
+			String targetModel//
+	) {
+		super(solver, genRules, opRules, negativeConstraints, inconsistencyReporter, builder, sourceModel, targetModel);
 	}
 
 	@Override

--- a/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/ForwardTransformationOperationalStrategy.java
+++ b/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/ForwardTransformationOperationalStrategy.java
@@ -5,6 +5,7 @@ import org.emoflon.neo.cypher.models.NeoCoreBuilder;
 import org.emoflon.neo.cypher.rules.NeoRule;
 import org.emoflon.neo.engine.api.constraints.IConstraint;
 import org.emoflon.neo.engine.generator.modules.ICleanupModule;
+import org.emoflon.neo.engine.generator.modules.IInconsistencyReporter;
 import org.emoflon.neo.engine.modules.ilp.ILPBasedOperationalStrategy;
 import org.emoflon.neo.engine.modules.ilp.ILPFactory.SupportedILPSolver;
 
@@ -20,6 +21,19 @@ public class ForwardTransformationOperationalStrategy extends ILPBasedOperationa
 			String targetModel//
 	) {
 		super(solver, genRules, opRules, negativeConstraints, builder, sourceModel, targetModel);
+	}
+	
+	public ForwardTransformationOperationalStrategy(//
+			SupportedILPSolver solver, //
+			NeoCoreBuilder builder, //
+			Collection<NeoRule> genRules, //
+			Collection<NeoRule> opRules, //
+			Collection<IConstraint> negativeConstraints, //
+			IInconsistencyReporter inconsistencyReporter, //
+			String sourceModel, //
+			String targetModel//
+	) {
+		super(solver, genRules, opRules, negativeConstraints, inconsistencyReporter, builder, sourceModel, targetModel);
 	}
 
 	@Override

--- a/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/ModelIntegrationOperationalStrategy.java
+++ b/org.emoflon.neo.engine.modules/src/org/emoflon/neo/engine/modules/updatepolicies/ModelIntegrationOperationalStrategy.java
@@ -15,6 +15,7 @@ import org.emoflon.neo.engine.api.constraints.IConstraint;
 import org.emoflon.neo.engine.api.rules.IRule;
 import org.emoflon.neo.engine.generator.MatchContainer;
 import org.emoflon.neo.engine.generator.modules.ICleanupModule;
+import org.emoflon.neo.engine.generator.modules.IInconsistencyReporter;
 import org.emoflon.neo.engine.generator.modules.IMonitor;
 import org.emoflon.neo.engine.modules.ilp.ILPBasedOperationalStrategy;
 import org.emoflon.neo.engine.modules.ilp.ILPFactory.SupportedILPSolver;
@@ -29,7 +30,7 @@ public class ModelIntegrationOperationalStrategy extends ILPBasedOperationalStra
 	private static double alpha; // delete-delta
 	private static double beta; // create-delta
 	private static double gamma; // added elements
-
+	
 	public ModelIntegrationOperationalStrategy(//
 			SupportedILPSolver solver, //
 			NeoCoreBuilder builder, //
@@ -39,7 +40,20 @@ public class ModelIntegrationOperationalStrategy extends ILPBasedOperationalStra
 			String sourceModel, //
 			String targetModel//
 	) {
-		super(solver, genRules, opRules, negativeConstraints, builder, sourceModel, targetModel);
+		this(solver, builder, genRules, opRules, negativeConstraints, null, sourceModel, targetModel);
+	}
+
+	public ModelIntegrationOperationalStrategy(//
+			SupportedILPSolver solver, //
+			NeoCoreBuilder builder, //
+			Collection<NeoRule> genRules, //
+			Collection<NeoRule> opRules, //
+			Collection<IConstraint> negativeConstraints, //
+			IInconsistencyReporter inconsistencyReporter, //
+			String sourceModel, //
+			String targetModel//
+	) {
+		super(solver, genRules, opRules, negativeConstraints, inconsistencyReporter, builder, sourceModel, targetModel);
 		setWeightings(builder.getAlpha(), builder.getBeta(), builder.getGamma());
 		opRuleNameToGenRule = new HashMap<>();
 		

--- a/org.emoflon.neo.engine/src/org/emoflon/neo/engine/generator/modules/IInconsistencyReporter.java
+++ b/org.emoflon.neo.engine/src/org/emoflon/neo/engine/generator/modules/IInconsistencyReporter.java
@@ -1,0 +1,7 @@
+package org.emoflon.neo.engine.generator.modules;
+
+import java.util.Collection;
+
+public interface IInconsistencyReporter {
+	void reportInconsistencies(Collection<Long> inconsistentNodeIds, Collection<Long> inconsistentRelationshipIds);
+}


### PR DESCRIPTION
The ILP solver only reported inconsistencies at certain log level to the console. However, if such inconsistencies shall be reported to end-users, they must be accessible in another form.
I've introduced an interface IInconsistencyReporter to which the ids of the inconsistent nodes and relationships are reported. I've added the inconcsistency reporter to the respective constructors and kept version of the constructor without it for backwards compatability.