### PR TITLE
Eclipse v2024-03 (+) compatibility

### DIFF
--- a/org.emoflon.neo.emf/META-INF/MANIFEST.MF
+++ b/org.emoflon.neo.emf/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Export-Package: .,
  org.emoflon.neo.emf,
  org.emoflon.neo.emf.handlers
-Require-Bundle: org.apache.commons.io;bundle-version="2.2.0";visibility:=reexport,
+Require-Bundle: org.apache.commons.commons-io;bundle-version="2.2.0";visibility:=reexport,
  com.google.guava;visibility:=reexport,
  org.eclipse.emf.ecore.xmi;bundle-version="2.15.0",
  org.emoflon.neo.emsl;bundle-version="1.0.0",


### PR DESCRIPTION
This PR changes the name of the Apache commons IO dependency in one of the `MANIFEST.MF` files to ensure compatibility with Eclipse v2024-03 and newer. From time to time, the dependency shipped with Eclipse itself changes the name and, thus, breaks the eMoflon implementation.

Without this fix, Eclipse gives a kind of cryptic error message:

```
Description	Resource	Path	Location	Type
Access restriction: The type FileUtils is not accessible due to restriction on required project org.emoflon.neo.emsl	EMFImporter.xtend	/org.emoflon.neo.emf/src/org/emoflon/neo/emf	line 6	Xtend Problem
Access restriction: The type FileUtils is not accessible due to restriction on required project org.emoflon.neo.emsl	EMFImporter.xtend	/org.emoflon.neo.emf/src/org/emoflon/neo/emf	line 116	Xtend Problem
```