### PR TITLE
Replaces `$collection.last` with `$collection.lastOrNull` in `EMSLGenerator.xtend`

### DIFF
--- a/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/generator/EMSLGenerator.xtend
+++ b/org.emoflon.neo.emsl/src/org/emoflon/neo/emsl/generator/EMSLGenerator.xtend
@@ -85,7 +85,7 @@ class EMSLGenerator extends AbstractGenerator {
 
 	def getAPIName(Resource resource) {
 		val segments = resource.URI.trimFileExtension.segmentsList
-		return segments.last
+		return segments.lastOrNull
 	}
 
 	def getAPIFileName(Resource resource) {


### PR DESCRIPTION
The former `$collection.last` produces an error in Java 21, which is the default since a few versions of Eclipse. The fix is to use `lastOrNull` instead.

See:
- https://github.com/eclipse-xtext/xtext/issues/2981
- https://github.com/jgraichen/timetable/commit/b6d3633d02141b08f1c3ae752132bf37691fde8d

With this fix, the development workspace compiles with Java 21 (hence, with the latest version of the Eclipse IDE) and all tests of the runtime workspace are green.